### PR TITLE
Fix inconsistent client key name

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ certificate can also be a self-signed one.
 Create a server key and certificate with the following command:
 
 ```
-$ openssl req  -nodes -new -x509 -keyout apiserver-clientkey.pem -out apiserver-client.pem
+$ openssl req  -nodes -new -x509 -keyout apiserver-client-key.pem -out apiserver-client.pem
 ```
 
 ## Kubernetes master node(s)


### PR DESCRIPTION
One of the openssl examples was missing a '-' from the key name, so
copying and pasting the examples would cause a configuration error on
kube-apiserver. This change ensures all the API server key paths are the
same.